### PR TITLE
feat: P1 message actions, activity timeline, and document drawer

### DIFF
--- a/P1_PLAN.md
+++ b/P1_PLAN.md
@@ -1,0 +1,377 @@
+# P1 Execution Plan — Message Actions · Tool Timeline · Doc Drawer
+
+> Branch: `feat/p1-message-actions-tool-timeline-doc-drawer`  
+> Baseline: P0 work from `feat/chatgpt-ui-p0-improvements` (merged into main → this branch forks from there)
+
+---
+
+## 0. Scope & Success Criteria
+
+| Feature | Done-when |
+|---|---|
+| **Per-message actions** | Every completed assistant message shows Copy / Regenerate / Edit / Continue. User messages show Edit-and-resubmit. All actions keyboard-accessible (focus-visible ring). |
+| **Tool-run timeline** | A collapsible "Activity" strip appears above assistant content whenever a message involved a tool call (search, thinking). Shows per-step status with timing. Collapsed by default after streaming. |
+| **Document drawer** | A pill/badge row above the composer always shows attached docs for the active conversation. Clicking opens a slide-in drawer with remove + attach-state. No new page needed—uses existing `DocumentPanel` internals. |
+
+All three must have unit/integration tests and must not break existing test suite.
+
+---
+
+## 1. File Map
+
+```
+src/
+  types/index.ts                       ← add ToolEvent to Message
+  stores/chatStore.ts                  ← add editAndResubmit(), regenerateAt()
+  components/
+    Chat/
+      ChatMessage.tsx                  ← message action bar + inline edit UI
+      ChatContainer.tsx                ← wire editAndResubmit / regenerateAt / doc drawer
+      MessageActionBar.tsx             ← NEW: extracted action bar component
+      ToolTimeline.tsx                 ← NEW: collapsible tool-run timeline
+    Documents/
+      DocDrawer.tsx                    ← NEW: slide-in doc drawer shell
+      DocDrawerTrigger.tsx             ← NEW: pill row above composer
+      DocumentPanel.tsx                ← unchanged (reused inside DocDrawer)
+```
+
+---
+
+## 2. Type Changes — `src/types/index.ts`
+
+### 2a. Add `ToolEvent` to track individual tool steps
+
+```ts
+export interface ToolEvent {
+  type: 'thinking' | 'search' | 'tool_call' | 'tool_result';
+  label: string;           // e.g. "Searched: what is RAG"
+  startedAt: number;       // ms timestamp
+  endedAt?: number;        // set when step completes
+  detail?: string;         // optional collapsed detail (query text, result count)
+}
+```
+
+### 2b. Extend `Message`
+
+```ts
+export interface Message {
+  // ... existing fields ...
+  toolEvents?: ToolEvent[];     // ordered log of tool steps for this turn
+  parentMessageId?: string;     // set when this message is a regen/edit branch
+  editedFrom?: string;          // original content if this was edited before submit
+}
+```
+
+**Why `toolEvents` on `Message` vs a separate store slice?**  
+Messages are already persisted via `StorageService.saveConversation()`. Attaching events to the message means the timeline is free with zero extra persistence logic.
+
+---
+
+## 3. Store Changes — `src/stores/chatStore.ts`
+
+### 3a. New actions to add to `ChatStore` interface
+
+```ts
+interface ChatStore {
+  // ... existing ...
+  regenerateAt: (assistantMessageIndex: number) => Promise<void>;
+  editAndResubmit: (userMessageIndex: number, newContent: string) => Promise<void>;
+}
+```
+
+### 3b. `regenerateAt` implementation strategy
+
+Current `handleRegenerate` in `ChatContainer` walks backwards to find the preceding user message and calls `sendMessage(content)`. This works but appends new messages; it doesn't replace the stale assistant response.
+
+New `regenerateAt(assistantMessageIndex)`:
+1. Find the preceding user message index `ui`.
+2. Slice `conversation.messages` to `[0 … ui]` (drop the stale assistant reply and everything after).
+3. Call internal `_sendFrom(userContent)` — same body as `sendMessage` but operates on the already-trimmed message array.
+4. Set `parentMessageId` on the new assistant message = ID of the message that was dropped.
+
+This gives the conversation a clean linear history while preserving the original in `parentMessageId` for potential future branching UI.
+
+### 3c. `editAndResubmit` implementation strategy
+
+```
+editAndResubmit(userMessageIndex, newContent):
+  1. Trim messages to [0 … userMessageIndex - 1]  (drop original user msg + everything after)
+  2. Set editedFrom = original user content on the new user message
+  3. Call sendMessage(newContent)
+```
+
+No new streaming logic needed—`sendMessage` already handles everything.
+
+### 3d. `toolEvents` population during streaming
+
+In the existing `sendMessage` flow, the store already sets `status: 'thinking'` and `status: 'searching'` on the assistant placeholder. Extend each of those transitions to also push a `ToolEvent`:
+
+| Existing transition | Also push ToolEvent |
+|---|---|
+| `status = 'thinking'` set | `{type:'thinking', label:'Thinking', startedAt: now}` |
+| Tool call detected (before execution) | `{type:'tool_call', label:'Calling web_search', startedAt: now}` |
+| `isSearching = true` / `lastSearchQuery` set | `{type:'search', label: 'Searched: ${query}', startedAt: now}` |
+| Tool result received | close previous event (`endedAt = now`), push `{type:'tool_result', label:'Got ${n} results', startedAt: now, endedAt: now}` |
+
+Helper: `appendToolEvent(messageId, event)` — a small Zustand set call that finds the message in `currentConversation.messages` by ID and appends to its `toolEvents` array.
+
+---
+
+## 4. Message Actions — `src/components/Chat/MessageActionBar.tsx` (NEW)
+
+### Props
+
+```ts
+interface MessageActionBarProps {
+  message: Message;
+  messageIndex: number;
+  isLatestAssistant: boolean;
+  isStreaming: boolean;
+  onCopy: () => void;
+  copied: boolean;
+  onRegenerate?: () => void;
+  onContinue?: () => void;
+  onEdit?: (newContent: string) => void;   // only for user messages
+}
+```
+
+### Layout
+
+```
+[assistant message]
+─────────────────────────────────────────
+  Copy  Regenerate  Continue             ← visible on hover OR focus-within
+  (icon + label, 28px tall, gap-1)
+```
+
+```
+[user message]
+─────────────────────────────────────────
+                              Edit  Copy ← right-aligned, hover/focus
+```
+
+### Interaction states
+
+| State | Visual |
+|---|---|
+| Default | `opacity-0` on the bar container |
+| Parent `group` hovered | `group-hover:opacity-100` |
+| Any button focused | `focus-within:opacity-100` on bar |
+| Streaming | Regenerate + Continue disabled (`cursor-not-allowed opacity-40`) |
+| Copied | "Copy" label → "Copied ✓" for 2 s |
+
+### Edit mode (user messages)
+
+When the user clicks **Edit**, the message bubble text swaps to a `<textarea>` pre-filled with `message.content`. Two inline buttons appear: **Submit** (calls `onEdit(newContent)`) and **Cancel** (restores text, exits edit mode). Textarea auto-resizes to content height using `onInput` height-setting pattern.
+
+### Changes to `ChatMessage.tsx`
+
+- Extract the existing action bar `<div>` (Copy + Regenerate + Continue buttons) into `<MessageActionBar>`.
+- Remove the duplicate hover-only copy button (`absolute top-2 right-2`) and consolidate into `MessageActionBar`; the absolute button adds visual noise and duplicates Copy.
+- Pass `onEdit` for user messages by wiring through `ChatContainer`.
+- Keep `isActivelyStreaming` prop as-is; pass directly to `MessageActionBar` to disable actions.
+
+---
+
+## 5. Tool-Run Timeline — `src/components/Chat/ToolTimeline.tsx` (NEW)
+
+### Props
+
+```ts
+interface ToolTimelineProps {
+  events: ToolEvent[];
+  isStreaming: boolean;    // when true, last event shows a live spinner
+}
+```
+
+### Visual design
+
+```
+▼ Activity (2 steps · 1.4 s)               ← collapsed pill, click to expand
+────────────────────────────────
+  💭 Thinking          0.3 s
+  🔎 Searched: "what is RAG"
+     ↳ Got 6 results   1.1 s
+────────────────────────────────
+```
+
+- Collapsed by default once `isStreaming` becomes false.
+- During streaming: auto-expanded, last event shows a `animate-pulse` spinner instead of duration.
+- Duration shown as `(endedAt - startedAt) / 1000` formatted to 1 decimal.
+- Rendered inside assistant message bubble, above the prose content, below any status bubble.
+- Controlled with local `useState<boolean>(isStreaming)` — collapses when streaming ends via `useEffect`.
+
+### Integration in `ChatMessage.tsx`
+
+```tsx
+// After the status-bubble block, before the prose block:
+{message.toolEvents && message.toolEvents.length > 0 && !message.status && (
+  <ToolTimeline events={message.toolEvents} isStreaming={isActivelyStreaming} />
+)}
+```
+
+---
+
+## 6. Document Drawer — `DocDrawerTrigger` + `DocDrawer`
+
+### 6a. `DocDrawerTrigger.tsx` (NEW)
+
+A horizontally scrollable pill row rendered **between** the message list and the composer in `ChatContainer`. Only shown when `uploadedDocuments.length > 0`.
+
+```
+[📄 report.pdf  ×]  [📄 notes.txt  ×]  [+ Add doc]
+```
+
+- Each pill: `rounded-full bg-gray-100 dark:bg-gray-800 px-3 py-1 text-xs flex items-center gap-2`.
+- `×` calls `removeDocument(doc.id)` directly (fast path, no drawer needed).
+- Clicking the pill label or **+ Add doc** opens `<DocDrawer>`.
+- `[+ Add doc]` also triggers a hidden `<input type="file">` via ref (same logic as existing `DocumentUploadButton`).
+
+### 6b. `DocDrawer.tsx` (NEW)
+
+A slide-in panel anchored to the right edge of the chat column (not full-screen overlay).
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Chat area                              │  Documents    ×   │
+│                                         │  ───────────────  │
+│                                         │  📄 report.pdf    │
+│                                         │     12 chunks · … │
+│                                         │                 × │
+│                                         │  📄 notes.txt     │
+│                                         │     4 chunks · …  │
+│                                         │                 × │
+│                                         │                   │
+│                                         │  + Upload new doc │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Props:
+```ts
+interface DocDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  documents: UploadedDocument[];
+  onRemove: (id: string) => void;
+  onUpload: (file: File) => void;
+}
+```
+
+- `open` drives a CSS transition: `translate-x-0` vs `translate-x-full` with `transition-transform duration-200`.
+- Reuses `DocumentPanel` for the list body (or inlines the same markup—`DocumentPanel` is small enough).
+- Width: `w-72` fixed; does not push the chat layout (absolute positioned inside the flex column).
+- Close on `Escape` keydown (add `useEffect` listener when `open`).
+- Close on backdrop click (transparent backdrop covers the chat area, `z-10` behind the drawer panel).
+
+### 6c. Mount in `ChatContainer.tsx`
+
+```tsx
+// State
+const [docDrawerOpen, setDocDrawerOpen] = useState(false);
+
+// In JSX, after messages list, before composer:
+{uploadedDocuments.length > 0 && (
+  <DocDrawerTrigger
+    documents={uploadedDocuments}
+    onOpen={() => setDocDrawerOpen(true)}
+    onRemove={removeDocument}
+    onUpload={uploadDocument}
+  />
+)}
+
+<DocDrawer
+  open={docDrawerOpen}
+  onClose={() => setDocDrawerOpen(false)}
+  documents={uploadedDocuments}
+  onRemove={removeDocument}
+  onUpload={uploadDocument}
+/>
+```
+
+---
+
+## 7. Test Plan — `src/components/Chat/__tests__/` and `src/stores/__tests__/`
+
+### 7a. Message actions — `message-actions.test.tsx` (update existing)
+
+| Test | Assertion |
+|---|---|
+| Copy button shows "Copied" after click | `userEvent.click` → text changes, reverts after 2 s (fake timers) |
+| Regenerate disabled while streaming | button has `disabled` attribute when `isStreaming=true` |
+| Edit mode: textarea appears on Edit click | `getByRole('textbox')` visible, pre-filled with original content |
+| Edit cancel: original content restored | no `onEdit` called, textarea gone |
+| Edit submit: `onEdit` called with new content | spy called once with new string |
+
+### 7b. `editAndResubmit` store action — `chatStore.edit.test.ts` (new file)
+
+| Test | Assertion |
+|---|---|
+| Trims messages correctly | messages after edit index removed before send |
+| `editedFrom` set on new user message | new user message has `editedFrom = original content` |
+| `sendMessage` called with new content | spy/mock verifies argument |
+
+### 7c. `regenerateAt` store action — `chatStore.regenerate.test.ts` (new file)
+
+| Test | Assertion |
+|---|---|
+| Stale assistant reply is dropped | conversation length decremented correctly |
+| `parentMessageId` set on new assistant message | ID matches dropped message |
+| No-op when streaming | `isStreaming` guard prevents execution |
+
+### 7d. ToolTimeline — `tool-timeline.test.tsx` (new file)
+
+| Test | Assertion |
+|---|---|
+| Collapsed by default after streaming=false | expand button text visible, steps hidden |
+| Auto-expands during streaming | steps visible, spinner shown |
+| Shows duration when event has endedAt | formatted time string rendered |
+| Click to expand/collapse toggles | step list visibility toggles |
+
+### 7e. DocDrawer — `doc-drawer.test.tsx` (new file)
+
+| Test | Assertion |
+|---|---|
+| Drawer hidden when `open=false` | `translate-x-full` class present |
+| Drawer visible when `open=true` | `translate-x-0` class present |
+| Escape key closes drawer | `onClose` spy called |
+| Remove button calls `onRemove` with correct id | spy called with doc id |
+| DocDrawerTrigger renders one pill per doc | correct number of pills |
+
+---
+
+## 8. Accessibility Checklist
+
+- All action buttons: `aria-label` set (e.g. `aria-label="Regenerate response"`).
+- Edit textarea: `aria-label="Edit message"`, focus trapped inside edit bubble while active.
+- ToolTimeline toggle: `aria-expanded` tracks collapsed state; `aria-controls` points to steps container.
+- DocDrawer: `role="dialog"`, `aria-modal="true"`, `aria-label="Document drawer"`. Focus moves to first interactive element on open; returns to trigger on close.
+- All interactive elements: `focus-visible:ring-2 focus-visible:ring-blue-500` (consistent with P0 ring styles).
+
+---
+
+## 9. Implementation Order
+
+```
+Step 1 — Types                (30 min)   src/types/index.ts
+Step 2 — Store actions        (1.5 h)    chatStore.ts  (+2 new test files)
+Step 3 — MessageActionBar     (1 h)      new file + ChatMessage.tsx refactor
+Step 4 — ToolTimeline         (1 h)      new file + ChatMessage.tsx mount point
+Step 5 — DocDrawerTrigger     (45 min)   new file + ChatContainer.tsx mount
+Step 6 — DocDrawer            (45 min)   new file (reuses DocumentPanel)
+Step 7 — Tests                (1.5 h)    update + new test files
+Step 8 — A11y pass            (30 min)   aria attrs, focus management
+Step 9 — PR                   (15 min)   gh pr create → base main
+```
+
+Total estimated: ~7.5 h focused work.
+
+---
+
+## 10. Deliberate Non-changes (Out of Scope for P1)
+
+- No branching/tree UI — `parentMessageId` is stored but no UI branch picker.  
+- No inline "Continue" prompt text editing — Continue always sends literal `"Continue."`.  
+- `DocumentPanel.tsx` itself is unchanged — drawer reuses it as-is.  
+- No changes to RAG/embedding logic — drawer is UI-only.  
+- No changes to `SettingsPanel` (P2 scope).  
+- No sidebar collapse (P2 scope).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,8 @@ function App() {
         <div className="flex-1 flex overflow-hidden">
           {/* Sidebar */}
           <aside className="w-80 flex-shrink-0 flex flex-col border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-            <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700 space-y-2">
+            <div className="flex-1 overflow-y-auto">
+            <div className="sticky top-0 z-10 px-3 py-2 bg-gray-50 dark:bg-gray-800 space-y-2">
               <div className="flex items-center justify-between gap-2">
                 <h1 className="text-base font-semibold text-gray-900 dark:text-white">LocalMind</h1>
                 <div className="flex items-center gap-1">
@@ -153,8 +154,8 @@ function App() {
               </div>
             </div>
 
-            <div className="flex-1 min-h-0">
-              <ConversationList
+
+            <ConversationList
                 conversations={conversations}
                 currentConversationId={currentConversation?.id || null}
                 onSelectConversation={loadConversation}

--- a/src/components/Chat/ChatContainer.tsx
+++ b/src/components/Chat/ChatContainer.tsx
@@ -1,14 +1,20 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { useChatStore } from '../../stores/chatStore';
 import { supportsTools } from '../../constants/models';
+import { DocDrawerTrigger } from '../Documents/DocDrawerTrigger';
+import { DocDrawer } from '../Documents/DocDrawer';
 
 export const ChatContainer: React.FC = () => {
   const { 
     currentConversation, 
     sendMessage, 
+    regenerateAt,
+    editAndResubmit,
     uploadDocument,
+    removeDocument,
+    uploadedDocuments,
     isIndexingDocument,
     indexingProgress,
     indexingFileName,
@@ -25,6 +31,7 @@ export const ChatContainer: React.FC = () => {
   } = useChatStore();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [isDocDrawerOpen, setIsDocDrawerOpen] = useState(false);
 
   // Auto-scroll to bottom when new messages arrive
   // Use instant scroll during streaming for better responsiveness
@@ -96,15 +103,7 @@ export const ChatContainer: React.FC = () => {
   };
 
   const handleRegenerate = (assistantMessageIndex: number) => {
-    if (!currentConversation || isStreaming) return;
-
-    for (let index = assistantMessageIndex - 1; index >= 0; index -= 1) {
-      const message = currentConversation.messages[index];
-      if (message.role === 'user') {
-        sendMessage(message.content, false);
-        return;
-      }
-    }
+    regenerateAt(assistantMessageIndex);
   };
 
   const handleContinue = () => {
@@ -112,8 +111,12 @@ export const ChatContainer: React.FC = () => {
     sendMessage('Continue.', false);
   };
 
+  const handleEditAndResubmit = (userMessageIndex: number, newContent: string) => {
+    editAndResubmit(userMessageIndex, newContent);
+  };
+
   return (
-    <div className="flex-1 flex flex-col h-full">
+    <div className="flex-1 flex flex-col h-full relative overflow-hidden">
       {/* Chat header with actions - Phase 2B: Enhanced with mode indicator */}
       {currentConversation && currentConversation.messages.length > 0 && (
         <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-3 py-2">
@@ -227,6 +230,11 @@ export const ChatContainer: React.FC = () => {
                     ? handleContinue
                     : undefined
                 }
+                onEdit={
+                  message.role === 'user'
+                    ? (newContent) => handleEditAndResubmit(index, newContent)
+                    : undefined
+                }
               />
             ))
           )}
@@ -234,6 +242,12 @@ export const ChatContainer: React.FC = () => {
           <div ref={messagesEndRef} />
         </div>
       </div>
+
+      <DocDrawerTrigger
+        documents={uploadedDocuments}
+        onOpen={() => setIsDocDrawerOpen(true)}
+        onRemove={removeDocument}
+      />
 
       {/* Input area */}
       <ChatInput 
@@ -246,6 +260,14 @@ export const ChatContainer: React.FC = () => {
         isStreaming={isStreaming}
         isSearching={isSearching}
         webSearchEnabled={settings.webSearchEnabled}
+      />
+
+      <DocDrawer
+        open={isDocDrawerOpen}
+        onClose={() => setIsDocDrawerOpen(false)}
+        documents={uploadedDocuments}
+        onRemove={removeDocument}
+        onUpload={uploadDocument}
       />
     </div>
   );

--- a/src/components/Chat/ChatContainer.tsx
+++ b/src/components/Chat/ChatContainer.tsx
@@ -69,23 +69,22 @@ export const ChatContainer: React.FC = () => {
 
   if (!currentConversation) {
     return (
-      <div className="flex-1 flex flex-col h-full">
-        <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-          <div className="text-center p-8">
-            <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Welcome to LocalMind</h2>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">Your private AI assistant. All conversations stay on your computer.</p>
-            <div className="text-6xl mb-4">🧠</div>
+      <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+        <div className="flex-1 flex items-center justify-center px-6">
+          <div className="w-full max-w-3xl text-center space-y-8">
+            <h2 className="text-4xl font-semibold text-gray-900 dark:text-white">Ready when you are.</h2>
+            <ChatInput
+              onSendMessage={handleSendMessage}
+              onUploadDocument={uploadDocument}
+              isIndexingDocument={isIndexingDocument}
+              disabled={!modelLoaded}
+              isStreaming={isStreaming}
+              isSearching={isSearching}
+              webSearchEnabled={settings.webSearchEnabled}
+              layout="centered"
+            />
           </div>
         </div>
-        <ChatInput 
-          onSendMessage={handleSendMessage} 
-          onUploadDocument={uploadDocument}
-          isIndexingDocument={isIndexingDocument}
-          disabled={!modelLoaded}
-          isStreaming={isStreaming}
-          isSearching={isSearching}
-          webSearchEnabled={settings.webSearchEnabled}
-        />
       </div>
     );
   }
@@ -115,44 +114,47 @@ export const ChatContainer: React.FC = () => {
     editAndResubmit(userMessageIndex, newContent);
   };
 
+  if (currentConversation.messages.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+        <div className="flex-1 flex items-center justify-center px-6">
+          <div className="w-full max-w-3xl text-center space-y-8">
+            <p className="text-gray-500 dark:text-gray-400">No messages yet. Start the conversation!</p>
+            <ChatInput
+              onSendMessage={handleSendMessage}
+              onUploadDocument={uploadDocument}
+              isIndexingDocument={isIndexingDocument}
+              indexingFileName={currentConversation.id === indexingConversationId ? indexingFileName : null}
+              indexingProgress={currentConversation.id === indexingConversationId ? indexingProgress : null}
+              disabled={!modelLoaded}
+              isStreaming={isStreaming}
+              isSearching={isSearching}
+              webSearchEnabled={settings.webSearchEnabled}
+              layout="centered"
+            />
+          </div>
+        </div>
+
+        <DocDrawer
+          open={isDocDrawerOpen}
+          onClose={() => setIsDocDrawerOpen(false)}
+          documents={uploadedDocuments}
+          onRemove={removeDocument}
+          onUpload={uploadDocument}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex-1 flex flex-col h-full relative overflow-hidden">
-      {/* Chat header with actions - Phase 2B: Enhanced with mode indicator */}
+    <div className="flex-1 flex flex-col h-full relative overflow-hidden bg-gray-50 dark:bg-gray-900">
       {currentConversation && currentConversation.messages.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-3 py-2">
-          <div className="flex items-center justify-between max-w-full">
-            {/* Left: Model info + capabilities */}
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-              <div className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                {selectedModel}
-              </div>
-              
-              {/* Capability badges */}
-              <div className="flex items-center gap-2 flex-shrink-0">
-                {supportsTools(selectedModel) && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 text-xs font-medium">
-                    Tools
-                  </span>
-                )}
-                
-                {settings.webSearchEnabled && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-xs font-medium">
-                    Web
-                  </span>
-                )}
-              </div>
-              
-              <div className="text-xs text-gray-500 dark:text-gray-400">
-                {currentConversation.messages.length} message{currentConversation.messages.length !== 1 ? 's' : ''}
-              </div>
-            </div>
-            
-            {/* Right: Actions */}
-          <div className="flex items-center gap-2">
+        <div className="px-4 py-2">
+          <div className="max-w-3xl mx-auto flex items-center justify-end gap-2">
             {/* Export Buttons */}
             <button
               onClick={() => handleExport('json')}
-              className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
+              className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200/60 dark:hover:bg-gray-800 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
               title="Export as JSON"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -162,7 +164,7 @@ export const ChatContainer: React.FC = () => {
             </button>
             <button
               onClick={() => handleExport('markdown')}
-              className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
+              className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200/60 dark:hover:bg-gray-800 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
               title="Export as Markdown"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -175,7 +177,7 @@ export const ChatContainer: React.FC = () => {
             {isStreaming && (
               <button
                 onClick={stopStreaming}
-                className="text-sm text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 hover:bg-orange-50 dark:hover:bg-orange-900 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
+                className="text-sm text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 hover:bg-orange-100/60 dark:hover:bg-orange-900/40 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
                 title="Stop generation"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -189,7 +191,7 @@ export const ChatContainer: React.FC = () => {
             {/* Clear Button */}
             <button
               onClick={handleClearConversation}
-              className="text-sm text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
+              className="text-sm text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-100/60 dark:hover:bg-red-900/40 px-2.5 py-1 rounded-md transition-colors flex items-center gap-1"
               title="Delete conversation"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -198,46 +200,39 @@ export const ChatContainer: React.FC = () => {
               Clear
             </button>
           </div>
-          </div>
         </div>
       )}
 
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900 px-3 py-2">
+      <div className="flex-1 overflow-y-auto px-3 py-2">
         <div className="max-w-3xl mx-auto">
-          {currentConversation.messages.length === 0 ? (
-            <div className="text-center text-gray-500 dark:text-gray-400 mt-8">
-              <p>No messages yet. Start the conversation!</p>
-            </div>
-          ) : (
-            currentConversation.messages.map((message, index) => (
-              <ChatMessage
-                key={message.id}
-                message={message}
-                isActivelyStreaming={
-                  isStreaming && index === currentConversation.messages.length - 1
-                }
-                isLatestAssistant={
-                  message.role === 'assistant' && index === currentConversation.messages.length - 1
-                }
-                onRegenerate={
-                  message.role === 'assistant'
-                    ? () => handleRegenerate(index)
-                    : undefined
-                }
-                onContinue={
-                  message.role === 'assistant' && index === currentConversation.messages.length - 1
-                    ? handleContinue
-                    : undefined
-                }
-                onEdit={
-                  message.role === 'user'
-                    ? (newContent) => handleEditAndResubmit(index, newContent)
-                    : undefined
-                }
-              />
-            ))
-          )}
+          {currentConversation.messages.map((message, index) => (
+            <ChatMessage
+              key={message.id}
+              message={message}
+              isActivelyStreaming={
+                isStreaming && index === currentConversation.messages.length - 1
+              }
+              isLatestAssistant={
+                message.role === 'assistant' && index === currentConversation.messages.length - 1
+              }
+              onRegenerate={
+                message.role === 'assistant'
+                  ? () => handleRegenerate(index)
+                  : undefined
+              }
+              onContinue={
+                message.role === 'assistant' && index === currentConversation.messages.length - 1
+                  ? handleContinue
+                  : undefined
+              }
+              onEdit={
+                message.role === 'user'
+                  ? (newContent) => handleEditAndResubmit(index, newContent)
+                  : undefined
+              }
+            />
+          ))}
 
           <div ref={messagesEndRef} />
         </div>
@@ -260,6 +255,7 @@ export const ChatContainer: React.FC = () => {
         isStreaming={isStreaming}
         isSearching={isSearching}
         webSearchEnabled={settings.webSearchEnabled}
+        layout="bottom"
       />
 
       <DocDrawer

--- a/src/components/Chat/ChatContainer.tsx
+++ b/src/components/Chat/ChatContainer.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { useChatStore } from '../../stores/chatStore';
-import { supportsTools } from '../../constants/models';
 import { DocDrawerTrigger } from '../Documents/DocDrawerTrigger';
 import { DocDrawer } from '../Documents/DocDrawer';
 
@@ -27,7 +26,6 @@ export const ChatContainer: React.FC = () => {
     stopStreaming,
     isSearching,
     settings,
-    selectedModel, // Phase 2B: Need selectedModel for header display
   } = useChatStore();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -11,6 +11,7 @@ interface ChatInputProps {
   isStreaming?: boolean;
   isSearching?: boolean;
   webSearchEnabled?: boolean;
+  layout?: 'bottom' | 'centered';
 }
 
 export const ChatInput: React.FC<ChatInputProps> = ({ 
@@ -23,6 +24,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   isStreaming = false,
   isSearching = false,
   webSearchEnabled = false, // Phase 2B: Now used for force search button
+  layout = 'bottom',
 }) => {
   const [input, setInput] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -64,14 +66,23 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [input]);
 
   return (
-    <form onSubmit={(e) => handleSubmit(e, false)} className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2">
+    <form
+      onSubmit={(e) => handleSubmit(e, false)}
+      className={`${
+        layout === 'centered'
+          ? 'w-full max-w-3xl mx-auto'
+          : 'bg-white/80 dark:bg-gray-900/80 backdrop-blur px-3 py-3'
+      }`}
+    >
       <div className="flex flex-col gap-2 max-w-4xl mx-auto">
 
         {/* File attachment pill — shows during indexing and while file is ready-to-send */}
         {indexingFileName && (
-          <div className="flex items-center gap-3 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm">
-            <div className="w-8 h-8 rounded-md bg-red-500 flex-shrink-0 flex items-center justify-center text-sm">
-              📄
+          <div className="flex items-center gap-3 px-3 py-2 rounded-xl bg-gray-100 dark:bg-gray-800/80">
+            <div className="w-8 h-8 rounded-md bg-red-500 flex-shrink-0 flex items-center justify-center text-white">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 3h7l5 5v13a1 1 0 01-1 1H7a1 1 0 01-1-1V4a1 1 0 011-1z" />
+              </svg>
             </div>
             <div className="min-w-0 flex-1">
               <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">{indexingFileName}</div>
@@ -95,11 +106,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         )}
 
         {/* Main input row */}
-        <div className="flex items-end rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1.5 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent transition-colors">
+        <div className="flex items-end rounded-3xl bg-gray-100 dark:bg-gray-800 px-3 py-2 transition-colors">
           <DocumentUploadButton
             onUpload={onUploadDocument}
             disabled={disabled || isIndexingDocument}
-            className="self-center h-8 w-8 px-0 py-0 border-0 rounded-md bg-transparent hover:bg-gray-100 dark:hover:bg-gray-600"
+            className="self-end bg-gray-200/80 dark:bg-gray-700/70 text-gray-700 dark:text-gray-200 hover:bg-gray-300/90 dark:hover:bg-gray-600/90"
           />
 
           <textarea
@@ -109,19 +120,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             onKeyDown={handleKeyDown}
             placeholder={isSearching ? "Searching the web..." : isStreaming ? "Waiting for response..." : "Ask anything"}
             disabled={disabled || isStreaming || isSearching}
-            className="flex-1 resize-none border-0 bg-transparent px-2.5 py-1.5 min-h-9 max-h-32 overflow-y-auto scrollbar-hide text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed"
+            className="flex-1 resize-none border-0 bg-transparent px-2.5 py-1.5 min-h-9 max-h-48 overflow-y-auto scrollbar-hide text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed"
             rows={1}
             style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           />
 
           {/* Button group */}
-          <div className="self-center flex items-center gap-2">
+          <div className="self-end flex items-center gap-2 pb-0.5">
             {/* Force search button - only show if web search enabled */}
             {webSearchEnabled && !isStreaming && !isSearching && input.trim() && (
               <button
                 type="button"
                 onClick={handleForceSearch}
-                className="h-8 px-3 rounded-md bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-sm font-medium hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors"
+                className="h-8 px-3 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
                 title="Search the web for this query"
               >
                 Web
@@ -132,7 +143,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             <button
               type="submit"
               disabled={!input.trim() || disabled || isStreaming || isSearching}
-              className="h-8 w-8 rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors inline-flex items-center justify-center"
+              className="h-10 w-10 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:opacity-90 disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:text-gray-200 dark:disabled:text-gray-300 disabled:cursor-not-allowed transition-colors inline-flex items-center justify-center"
               title="Send message"
             >
               {isSearching ? (

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -1,10 +1,12 @@
-import { Children, Fragment, useMemo, useState } from 'react';
+import { Children, Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { Message } from '../../types';
 import { CitationPill } from './CitationPill';
+import { MessageActionBar } from './MessageActionBar';
+import { ToolTimeline } from './ToolTimeline';
 
 interface ChatMessageProps {
   message: Message;
@@ -16,6 +18,7 @@ interface ChatMessageProps {
   isLatestAssistant?: boolean;
   onRegenerate?: () => void;
   onContinue?: () => void;
+  onEdit?: (newContent: string) => void;
 }
 
 export const ChatMessage: React.FC<ChatMessageProps> = ({
@@ -24,11 +27,30 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   isLatestAssistant = false,
   onRegenerate,
   onContinue,
+  onEdit,
 }) => {
   const isUser = message.role === 'user';
   const [copied, setCopied] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState(message.content);
+  const editTextAreaRef = useRef<HTMLTextAreaElement>(null);
   // Track which sources are actually cited inline to show a summary later
   const usedUrls = new Set<string>();
+
+  useEffect(() => {
+    setEditText(message.content);
+    setIsEditing(false);
+  }, [message.id, message.content]);
+
+  useEffect(() => {
+    if (!isEditing || !editTextAreaRef.current) {
+      return;
+    }
+
+    const textarea = editTextAreaRef.current;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [isEditing, editText]);
 
   // Preprocess content to remove References/Sources sections and track citations
   const processedContent = useMemo(() => {
@@ -72,6 +94,18 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
     }
   };
 
+  const handleEditSubmit = () => {
+    const normalizedContent = editText.trim();
+    if (!normalizedContent || normalizedContent === message.content) {
+      setIsEditing(false);
+      setEditText(message.content);
+      return;
+    }
+
+    onEdit?.(normalizedContent);
+    setIsEditing(false);
+  };
+
   return (
     <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
       <div className={`max-w-[80%] ${isUser ? 'order-2' : 'order-1'}`}>
@@ -83,7 +117,11 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
                 className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-xl bg-red-500 flex items-center justify-center text-lg">📄</div>
+                  <div className="w-10 h-10 rounded-xl bg-red-500 flex items-center justify-center text-white">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 3h7l5 5v13a1 1 0 01-1 1H7a1 1 0 01-1-1V4a1 1 0 011-1z" />
+                    </svg>
+                  </div>
                   <div className="min-w-0">
                     <div className="text-sm font-semibold truncate">{attachment.name}</div>
                     <div className="text-xs text-gray-500 dark:text-gray-300 uppercase">
@@ -104,7 +142,44 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
             }`}
           >
             {isUser ? (
-              <p className="whitespace-pre-wrap break-words">{message.content}</p>
+              isEditing ? (
+                <div className="space-y-2">
+                  <textarea
+                    ref={editTextAreaRef}
+                    value={editText}
+                    onChange={(event) => setEditText(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape') {
+                        event.preventDefault();
+                        setIsEditing(false);
+                        setEditText(message.content);
+                      }
+                    }}
+                    className="w-full rounded-md border border-blue-300 bg-white text-gray-900 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 resize-none"
+                    rows={3}
+                    aria-label="Edit message"
+                  />
+                  <div className="flex items-center justify-end gap-2 text-xs">
+                    <button
+                      onClick={() => {
+                        setIsEditing(false);
+                        setEditText(message.content);
+                      }}
+                      className="px-2 py-1 rounded border border-blue-200 text-blue-100 hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleEditSubmit}
+                      className="px-2 py-1 rounded border border-blue-200 text-blue-100 hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                    >
+                      Submit
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <p className="whitespace-pre-wrap break-words">{message.content}</p>
+              )
             ) : (
               <>
                 {/* Status bubble states - Phase 2B: Enhanced animations */}
@@ -112,9 +187,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
                   <div className="space-y-2">
                     {/* Main indicator */}
                     <div className="flex items-center gap-3 text-blue-600 dark:text-blue-400">
-                      <span className="inline-flex items-center justify-center w-6 h-6 animate-spin-slow">
-                        🔎
-                      </span>
+                      <span className="inline-flex items-center justify-center w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
                       <div className="flex flex-col">
                         <span className="font-semibold">Searching the web</span>
                         {message.lastSearchQuery && (
@@ -134,9 +207,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
                 {message.status === 'thinking' && (
                   <div className="space-y-2">
                     <div className="flex items-center gap-3 text-purple-600 dark:text-purple-400">
-                      <span className="inline-flex items-center justify-center w-6 h-6 animate-pulse">
-                        💭
-                      </span>
+                      <span className="inline-flex items-center justify-center w-2 h-2 rounded-full bg-purple-500 animate-pulse" />
                       <span className="font-semibold">Thinking</span>
                     </div>
                     
@@ -145,6 +216,13 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
                       <div className="h-full bg-gradient-to-r from-purple-500 to-pink-500 animate-progress-bar" />
                     </div>
                   </div>
+                )}
+
+                {message.toolEvents && message.toolEvents.length > 0 && !message.status && (
+                  <ToolTimeline
+                    events={message.toolEvents}
+                    isStreaming={isActivelyStreaming}
+                  />
                 )}
 
                 <div className={`prose prose-sm dark:prose-invert max-w-none prose-pre:p-0 prose-pre:m-0 ${message.status ? 'hidden' : ''}`}>
@@ -304,56 +382,34 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
 
                 {/* Message action bar */}
                 {!message.status && (
-                  <div className="mt-2 flex items-center gap-2 text-xs">
-                    <button
-                      onClick={handleCopy}
-                      className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 transition-colors"
-                    >
-                      {copied ? 'Copied' : 'Copy'}
-                    </button>
-                    {isLatestAssistant && onRegenerate && (
-                      <button
-                        onClick={onRegenerate}
-                        className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 transition-colors"
-                      >
-                        Regenerate
-                      </button>
-                    )}
-                    {isLatestAssistant && onContinue && (
-                      <button
-                        onClick={onContinue}
-                        className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 transition-colors"
-                      >
-                        Continue
-                      </button>
-                    )}
-                  </div>
+                  <MessageActionBar
+                    isUser={false}
+                    isStreaming={isActivelyStreaming}
+                    copied={copied}
+                    canRegenerate={Boolean(onRegenerate)}
+                    canContinue={Boolean(onContinue && isLatestAssistant)}
+                    canEdit={false}
+                    onCopy={handleCopy}
+                    onRegenerate={onRegenerate}
+                    onContinue={isLatestAssistant ? onContinue : undefined}
+                  />
                 )}
               </>
             )}
           </div>
-
-          {/* Copy button */}
-          <button
-            onClick={handleCopy}
-            className={`absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded ${
-              isUser 
-                ? 'bg-blue-700 hover:bg-blue-800 text-white' 
-                : 'bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600'
-            }`}
-            title="Copy message"
-          >
-            {copied ? (
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-              </svg>
-            )}
-          </button>
         </div>
+        {!message.status && isUser && !isEditing && (
+          <MessageActionBar
+            isUser={true}
+            isStreaming={isActivelyStreaming}
+            copied={copied}
+            canRegenerate={false}
+            canContinue={false}
+            canEdit={Boolean(onEdit)}
+            onCopy={handleCopy}
+            onStartEdit={() => setIsEditing(true)}
+          />
+        )}
         <div className={`text-xs text-gray-500 mt-1 ${isUser ? 'text-right' : 'text-left'}`}>
           {new Date(message.timestamp).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
         </div>

--- a/src/components/Chat/MessageActionBar.tsx
+++ b/src/components/Chat/MessageActionBar.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+interface MessageActionBarProps {
+  isUser: boolean;
+  isStreaming: boolean;
+  copied: boolean;
+  canRegenerate: boolean;
+  canContinue: boolean;
+  canEdit: boolean;
+  onCopy: () => void;
+  onRegenerate?: () => void;
+  onContinue?: () => void;
+  onStartEdit?: () => void;
+}
+
+const baseButtonClass =
+  'px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500';
+
+export const MessageActionBar: React.FC<MessageActionBarProps> = ({
+  isUser,
+  isStreaming,
+  copied,
+  canRegenerate,
+  canContinue,
+  canEdit,
+  onCopy,
+  onRegenerate,
+  onContinue,
+  onStartEdit,
+}) => {
+  return (
+    <div
+      className={`mt-2 flex items-center gap-2 text-xs opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity ${
+        isUser ? 'justify-end' : 'justify-start'
+      }`}
+    >
+      {isUser && canEdit && onStartEdit && (
+        <button
+          onClick={onStartEdit}
+          className={baseButtonClass}
+          aria-label="Edit message"
+        >
+          Edit
+        </button>
+      )}
+
+      <button
+        onClick={onCopy}
+        className={baseButtonClass}
+        aria-label="Copy message"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+
+      {!isUser && canRegenerate && onRegenerate && (
+        <button
+          onClick={onRegenerate}
+          disabled={isStreaming}
+          className={`${baseButtonClass} ${isStreaming ? 'cursor-not-allowed opacity-40' : ''}`}
+          aria-label="Regenerate response"
+        >
+          Regenerate
+        </button>
+      )}
+
+      {!isUser && canContinue && onContinue && (
+        <button
+          onClick={onContinue}
+          disabled={isStreaming}
+          className={`${baseButtonClass} ${isStreaming ? 'cursor-not-allowed opacity-40' : ''}`}
+          aria-label="Continue response"
+        >
+          Continue
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/Chat/ToolTimeline.tsx
+++ b/src/components/Chat/ToolTimeline.tsx
@@ -33,11 +33,11 @@ export const ToolTimeline: React.FC<ToolTimelineProps> = ({ events, isStreaming 
   }, [events]);
 
   return (
-    <div className="mb-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/40">
+    <div className="mb-3 rounded-xl bg-gray-100 dark:bg-gray-800/60">
       <button
         type="button"
         onClick={() => setExpanded((previous) => !previous)}
-        className="w-full px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        className="w-full px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 flex items-center justify-between focus-visible:outline-none"
         aria-expanded={expanded}
         aria-controls={timelineId}
       >

--- a/src/components/Chat/ToolTimeline.tsx
+++ b/src/components/Chat/ToolTimeline.tsx
@@ -1,0 +1,74 @@
+import React, { useId, useMemo, useState } from 'react';
+import type { ToolEvent } from '../../types';
+
+interface ToolTimelineProps {
+  events: ToolEvent[];
+  isStreaming: boolean;
+}
+
+const formatDuration = (startedAt: number, endedAt?: number): string => {
+  if (!endedAt || endedAt < startedAt) {
+    return '';
+  }
+
+  return `${((endedAt - startedAt) / 1000).toFixed(1)}s`;
+};
+
+export const ToolTimeline: React.FC<ToolTimelineProps> = ({ events, isStreaming }) => {
+  const timelineId = useId();
+  const [expanded, setExpanded] = useState(false);
+
+  const summaryDuration = useMemo(() => {
+    if (!events.length) {
+      return '';
+    }
+
+    const first = events[0].startedAt;
+    const lastWithEnd = [...events].reverse().find((event) => event.endedAt);
+    if (!lastWithEnd?.endedAt) {
+      return '';
+    }
+
+    return `${((lastWithEnd.endedAt - first) / 1000).toFixed(1)}s`;
+  }, [events]);
+
+  return (
+    <div className="mb-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/40">
+      <button
+        type="button"
+        onClick={() => setExpanded((previous) => !previous)}
+        className="w-full px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        aria-expanded={expanded}
+        aria-controls={timelineId}
+      >
+        <span>Activity ({events.length} step{events.length !== 1 ? 's' : ''})</span>
+        <span className="text-gray-500 dark:text-gray-400">{summaryDuration || (isStreaming ? 'Running' : '')}</span>
+      </button>
+
+      {expanded && (
+        <div id={timelineId} className="px-3 pb-3 space-y-2">
+          {events.map((event, index) => {
+            const isLatest = index === events.length - 1;
+            const isActive = isStreaming && isLatest && !event.endedAt;
+            return (
+              <div key={`${event.label}-${event.startedAt}-${index}`} className="flex items-start justify-between gap-3 text-xs">
+                <div className="min-w-0">
+                  <div className="text-gray-800 dark:text-gray-200">{event.label}</div>
+                  {event.detail && (
+                    <div className="text-gray-500 dark:text-gray-400 truncate">{event.detail}</div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0 text-gray-500 dark:text-gray-400">
+                  {isActive ? (
+                    <span className="inline-block h-2 w-2 rounded-full bg-blue-500 animate-pulse" aria-hidden="true" />
+                  ) : null}
+                  <span>{formatDuration(event.startedAt, event.endedAt) || (isActive ? 'Running' : '')}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Chat/__tests__/tool-timeline.test.tsx
+++ b/src/components/Chat/__tests__/tool-timeline.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ToolTimeline } from '../ToolTimeline';
+import type { ToolEvent } from '../../../types';
+
+describe('ToolTimeline', () => {
+  const baseEvents: ToolEvent[] = [
+    { type: 'thinking', label: 'Thinking', startedAt: 1000, endedAt: 1300 },
+    { type: 'search', label: 'Searching web', startedAt: 1300, endedAt: 2100, detail: 'rag retrieval' },
+  ];
+
+  test('renders activity summary', () => {
+    const html = renderToStaticMarkup(<ToolTimeline events={baseEvents} isStreaming={false} />);
+
+    expect(html).toContain('Activity (2 steps)');
+    expect(html).toContain('1.1s');
+  });
+
+  test('is collapsed by default while streaming', () => {
+    const html = renderToStaticMarkup(<ToolTimeline events={baseEvents} isStreaming={true} />);
+
+    expect(html).toContain('Activity (2 steps)');
+    expect(html).not.toContain('rag retrieval');
+  });
+});

--- a/src/components/Documents/DocDrawer.tsx
+++ b/src/components/Documents/DocDrawer.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useId, useRef } from 'react';
+import type { UploadedDocument } from '../../types';
+import { DocumentPanel } from './DocumentPanel';
+
+interface DocDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  documents: UploadedDocument[];
+  onRemove: (id: string) => void;
+  onUpload: (file: File) => void;
+}
+
+export const DocDrawer: React.FC<DocDrawerProps> = ({
+  open,
+  onClose,
+  documents,
+  onRemove,
+  onUpload,
+}) => {
+  const headingId = useId();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    closeButtonRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      onUpload(file);
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={`absolute inset-0 z-10 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        className={`absolute top-0 right-0 bottom-0 z-20 w-72 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 transition-transform duration-200 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <div className="h-full flex flex-col">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+            <h2 id={headingId} className="text-sm font-semibold text-gray-900 dark:text-white">Documents</h2>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              className="text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+              aria-label="Close document drawer"
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto">
+            <DocumentPanel documents={documents} onRemoveDocument={onRemove} />
+          </div>
+
+          <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={handleUploadClick}
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Upload document
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept=".txt,.md,.pdf"
+              onChange={handleFileChange}
+            />
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+};

--- a/src/components/Documents/DocDrawerTrigger.tsx
+++ b/src/components/Documents/DocDrawerTrigger.tsx
@@ -17,7 +17,7 @@ export const DocDrawerTrigger: React.FC<DocDrawerTriggerProps> = ({
   }
 
   return (
-    <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2">
+    <div className="bg-transparent px-3 py-2">
       <div className="max-w-3xl mx-auto flex items-center gap-2 overflow-x-auto">
         {documents.map((document) => (
           <div

--- a/src/components/Documents/DocDrawerTrigger.tsx
+++ b/src/components/Documents/DocDrawerTrigger.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { UploadedDocument } from '../../types';
+
+interface DocDrawerTriggerProps {
+  documents: UploadedDocument[];
+  onOpen: () => void;
+  onRemove: (id: string) => void;
+}
+
+export const DocDrawerTrigger: React.FC<DocDrawerTriggerProps> = ({
+  documents,
+  onOpen,
+  onRemove,
+}) => {
+  if (!documents.length) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2">
+      <div className="max-w-3xl mx-auto flex items-center gap-2 overflow-x-auto">
+        {documents.map((document) => (
+          <div
+            key={document.id}
+            className="inline-flex items-center gap-2 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-3 py-1 text-xs min-w-0"
+          >
+            <button
+              type="button"
+              onClick={onOpen}
+              className="truncate max-w-[180px] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+              aria-label={`Open document drawer for ${document.name}`}
+            >
+              {document.name}
+            </button>
+            <button
+              type="button"
+              onClick={() => onRemove(document.id)}
+              className="text-gray-500 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+              aria-label={`Remove ${document.name}`}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+
+        <button
+          type="button"
+          onClick={onOpen}
+          className="inline-flex items-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 px-3 py-1 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="Open document drawer"
+        >
+          Manage docs
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Documents/DocumentUploadButton.tsx
+++ b/src/components/Documents/DocumentUploadButton.tsx
@@ -59,11 +59,11 @@ export const DocumentUploadButton: React.FC<DocumentUploadButtonProps> = ({
         type="button"
         onClick={handleToggleMenu}
         disabled={disabled}
-        className={`inline-flex items-center justify-center leading-none px-3 py-3 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${className}`}
+        className={`inline-flex h-10 w-10 items-center justify-center rounded-full text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
         title="Add attachment"
         aria-label="Add attachment"
       >
-        <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg aria-hidden="true" className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.25} d="M12 4v16m8-8H4" />
         </svg>
       </button>

--- a/src/components/Documents/__tests__/doc-drawer.test.tsx
+++ b/src/components/Documents/__tests__/doc-drawer.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DocDrawer } from '../DocDrawer';
+import { DocDrawerTrigger } from '../DocDrawerTrigger';
+import type { UploadedDocument } from '../../../types';
+
+const documents: UploadedDocument[] = [
+  {
+    id: 'doc-1',
+    conversationId: 'conv-1',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    sizeBytes: 1234,
+    uploadedAt: Date.now(),
+    chunkCount: 2,
+    embeddingModel: 'bge-m3',
+  },
+];
+
+describe('DocDrawer', () => {
+  test('renders hidden class when closed', () => {
+    const html = renderToStaticMarkup(
+      <DocDrawer open={false} onClose={() => {}} documents={documents} onRemove={() => {}} onUpload={() => {}} />
+    );
+
+    expect(html).toContain('translate-x-full');
+  });
+
+  test('renders visible class when open', () => {
+    const html = renderToStaticMarkup(
+      <DocDrawer open={true} onClose={() => {}} documents={documents} onRemove={() => {}} onUpload={() => {}} />
+    );
+
+    expect(html).toContain('translate-x-0');
+  });
+});
+
+describe('DocDrawerTrigger', () => {
+  test('renders document pills', () => {
+    const html = renderToStaticMarkup(<DocDrawerTrigger documents={documents} onOpen={() => {}} onRemove={() => {}} />);
+
+    expect(html).toContain('notes.txt');
+    expect(html).toContain('Manage docs');
+  });
+});

--- a/src/components/Sidebar/ConversationList.tsx
+++ b/src/components/Sidebar/ConversationList.tsx
@@ -86,9 +86,9 @@ export const ConversationList: React.FC<ConversationListProps> = ({
   };
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-800">
+    <div className="flex flex-col bg-gray-50 dark:bg-gray-800">
       {/* New Chat Button */}
-      <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+      <div className="p-3">
         <button
           onClick={onNewConversation}
           className="w-full px-3 py-2 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 transition-colors flex items-center justify-center gap-1.5"
@@ -136,7 +136,7 @@ export const ConversationList: React.FC<ConversationListProps> = ({
       </div>
 
       {/* Conversations List */}
-      <div className="flex-1 overflow-y-auto">
+      <div>
         {filteredConversations.length === 0 ? (
           <div className="p-3 text-center text-gray-500 dark:text-gray-300 text-sm">
             {conversationsForTab.length === 0
@@ -151,7 +151,7 @@ export const ConversationList: React.FC<ConversationListProps> = ({
                 className={`
                   group relative mb-1 p-2.5 rounded-md cursor-pointer transition-colors
                   ${currentConversationId === conversation.id 
-                    ? 'bg-white dark:bg-gray-700 shadow-sm border border-blue-200 dark:border-blue-500' 
+                    ? 'bg-white dark:bg-gray-700 shadow-sm' 
                     : 'hover:bg-white dark:hover:bg-gray-700'
                   }
                 `}
@@ -190,14 +190,7 @@ export const ConversationList: React.FC<ConversationListProps> = ({
                         </p>
                       </div>
                     )}
-                    <div className="flex items-center gap-2 mt-1">
-                      <span className="text-xs text-gray-500 dark:text-gray-300 whitespace-nowrap">
-                        {formatDate(conversation.updatedAt)}
-                      </span>
-                      <span className="text-xs text-gray-400 dark:text-gray-400 whitespace-nowrap">
-                        {conversation.messages.length} messages
-                      </span>
-                    </div>
+
                   </div>
 
                   {/* Action menu */}
@@ -275,7 +268,7 @@ export const ConversationList: React.FC<ConversationListProps> = ({
       </div>
 
       {/* Footer */}
-      <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+      <div className="sticky bottom-0 p-3 bg-gray-50 dark:bg-gray-800">
         <div className="text-xs text-gray-500 dark:text-gray-400 text-center">
           {conversationsForTab.length} {showArchived ? 'archived' : 'active'} conversation{conversationsForTab.length !== 1 ? 's' : ''}
         </div>

--- a/src/components/Sidebar/ConversationList.tsx
+++ b/src/components/Sidebar/ConversationList.tsx
@@ -28,20 +28,6 @@ export const ConversationList: React.FC<ConversationListProps> = ({
   const [showArchived, setShowArchived] = useState(false);
   const [openActionsConversationId, setOpenActionsConversationId] = useState<string | null>(null);
 
-  const formatDate = (timestamp: number) => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-    
-    if (diffInHours < 24) {
-      return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-    } else if (diffInHours < 24 * 7) {
-      return date.toLocaleDateString('en-US', { weekday: 'short' });
-    } else {
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    }
-  };
-
   const getConversationPreview = (conversation: Conversation): string => {
     return conversation.title || 'New conversation';
   };

--- a/src/stores/__tests__/chatStore.actions.integration.test.ts
+++ b/src/stores/__tests__/chatStore.actions.integration.test.ts
@@ -1,0 +1,78 @@
+import { act } from 'react';
+import { useChatStore } from '../chatStore';
+import type { Conversation } from '../../types';
+
+jest.mock('../../services/storage.service', () => ({
+  StorageService: {
+    saveConversation: jest.fn(),
+    loadConversation: jest.fn(),
+    loadAllConversations: jest.fn(() => []),
+    deleteConversation: jest.fn(),
+  },
+}));
+
+describe('chatStore P1 actions', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      currentConversation: null,
+      conversations: [],
+      isStreaming: false,
+    });
+  });
+
+  test('regenerateAt trims to prior user message and forwards parentMessageId', async () => {
+    const conversation: Conversation = {
+      id: 'conv-1',
+      title: 'Test',
+      model: 'llama3.2:latest',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      messages: [
+        { id: 'u1', role: 'user', content: 'First', timestamp: 1 },
+        { id: 'a1', role: 'assistant', content: 'First answer', timestamp: 2 },
+      ],
+    };
+
+    const sendSpy = jest.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      currentConversation: conversation,
+      conversations: [conversation],
+      sendMessage: sendSpy,
+    } as any);
+
+    await act(async () => {
+      await useChatStore.getState().regenerateAt(1);
+    });
+
+    expect(useChatStore.getState().currentConversation?.messages).toHaveLength(1);
+    expect(sendSpy).toHaveBeenCalledWith('First', false, { parentMessageId: 'a1' });
+  });
+
+  test('editAndResubmit trims after previous message and sets editedFrom metadata', async () => {
+    const conversation: Conversation = {
+      id: 'conv-2',
+      title: 'Test',
+      model: 'llama3.2:latest',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      messages: [
+        { id: 'u1', role: 'user', content: 'Original question', timestamp: 1 },
+        { id: 'a1', role: 'assistant', content: 'Original answer', timestamp: 2 },
+      ],
+    };
+
+    const sendSpy = jest.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      currentConversation: conversation,
+      conversations: [conversation],
+      sendMessage: sendSpy,
+    } as any);
+
+    await act(async () => {
+      await useChatStore.getState().editAndResubmit(0, 'Updated question');
+    });
+
+    expect(useChatStore.getState().currentConversation?.messages).toHaveLength(0);
+    expect(sendSpy).toHaveBeenCalledWith('Updated question', false, { editedFrom: 'Original question' });
+  });
+});

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -53,7 +53,13 @@ interface ChatStore {
   initializeApp: () => Promise<void>;
   getModelStatus: () => 'offline' | 'loading' | 'ready';
   createNewConversation: () => void;
-  sendMessage: (content: string, forceSearch?: boolean) => Promise<void>; // Phase 2B: forceSearch param
+  sendMessage: (
+    content: string,
+    forceSearch?: boolean,
+    metadata?: { parentMessageId?: string; editedFrom?: string }
+  ) => Promise<void>; // Phase 2B: forceSearch param
+  regenerateAt: (assistantMessageIndex: number) => Promise<void>;
+  editAndResubmit: (userMessageIndex: number, newContent: string) => Promise<void>;
   stopStreaming: () => void;
   loadConversation: (id: string) => Promise<void>;
   deleteConversation: (id: string) => Promise<void>;
@@ -228,7 +234,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   // Send a message
-  sendMessage: async (content: string, forceSearch = false) => { // Phase 2B: forceSearch param
+  sendMessage: async (
+    content: string,
+    forceSearch = false,
+    metadata?: { parentMessageId?: string; editedFrom?: string }
+  ) => { // Phase 2B: forceSearch param
     const { currentConversation, selectedModel, settings, modelLoaded } = get();
     
     // Phase 3B: Start debug logging
@@ -355,6 +365,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       role: 'user',
       content,
       timestamp: Date.now(),
+      editedFrom: metadata?.editedFrom,
       attachments: get()
         .uploadedDocuments
         .filter((doc) =>
@@ -375,6 +386,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       content: '',
       timestamp: Date.now(),
       status: 'thinking',
+      parentMessageId: metadata?.parentMessageId,
+      toolEvents: [{ type: 'thinking', label: 'Thinking', startedAt: Date.now() }],
     };
 
     // Update conversation with user message and assistant placeholder
@@ -434,6 +447,57 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         nextState.currentConversation = updated;
       }
       set(nextState);
+    };
+
+    const appendToolEvent = (conversationId: string, messageId: string, event: NonNullable<Message['toolEvents']>[number]) => {
+      updateConversationById(conversationId, (conv) => {
+        const messages = conv.messages.map((message) => {
+          if (message.id !== messageId) {
+            return message;
+          }
+
+          return {
+            ...message,
+            toolEvents: [...(message.toolEvents || []), event],
+          };
+        });
+
+        return {
+          ...conv,
+          messages,
+          updatedAt: Date.now(),
+        };
+      });
+    };
+
+    const closeLastToolEvent = (conversationId: string, messageId: string) => {
+      updateConversationById(conversationId, (conv) => {
+        const messages = conv.messages.map((message) => {
+          if (message.id !== messageId || !message.toolEvents?.length) {
+            return message;
+          }
+
+          const nextEvents = [...message.toolEvents];
+          const lastEvent = nextEvents[nextEvents.length - 1];
+          if (!lastEvent.endedAt) {
+            nextEvents[nextEvents.length - 1] = {
+              ...lastEvent,
+              endedAt: Date.now(),
+            };
+          }
+
+          return {
+            ...message,
+            toolEvents: nextEvents,
+          };
+        });
+
+        return {
+          ...conv,
+          messages,
+          updatedAt: Date.now(),
+        };
+      });
     };
 
     // Save conversation
@@ -529,6 +593,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           apiMessages,
           5, // max iterations
           (toolName, args) => {
+            const toolStartedAt = Date.now();
+            closeLastToolEvent(activeConversationId, assistantMessage.id);
+            appendToolEvent(activeConversationId, assistantMessage.id, {
+              type: 'tool_call',
+              label: `Calling ${toolName}`,
+              startedAt: toolStartedAt,
+              endedAt: toolStartedAt,
+            });
+
             // Inject maxSearchResults into web_search args if not specified
             if (toolName === 'web_search' && !args.max_results && settings.maxSearchResults) {
               args.max_results = settings.maxSearchResults;
@@ -552,9 +625,29 @@ export const useChatStore = create<ChatStore>((set, get) => ({
               }
               return { ...conv, messages };
             });
+
+            if (toolName === 'web_search' && args.query) {
+              appendToolEvent(activeConversationId, assistantMessage.id, {
+                type: 'search',
+                label: 'Searching web',
+                detail: String(args.query),
+                startedAt: Date.now(),
+              });
+            }
           },
           (toolResult) => {
             console.log('[ChatStore] Tool result:', toolResult);
+            closeLastToolEvent(activeConversationId, assistantMessage.id);
+
+            appendToolEvent(activeConversationId, assistantMessage.id, {
+              type: 'tool_result',
+              label: toolResult.success ? 'Received tool result' : 'Tool error',
+              detail: toolResult.success
+                ? (toolResult.data?.results ? `${toolResult.data.results.length} results` : undefined)
+                : toolResult.error,
+              startedAt: Date.now(),
+              endedAt: Date.now(),
+            });
             
             // Phase 3B: Log search results or error
             if (settings.debugMode && logId) {
@@ -596,6 +689,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           const messages = [...conv.messages];
           const last = messages[messages.length - 1];
           if (last && last.role === 'assistant') {
+            if (last.toolEvents?.length) {
+              const nextEvents = [...last.toolEvents];
+              const lastEvent = nextEvents[nextEvents.length - 1];
+              if (lastEvent && !lastEvent.endedAt) {
+                nextEvents[nextEvents.length - 1] = { ...lastEvent, endedAt: Date.now() };
+              }
+              last.toolEvents = nextEvents;
+            }
             last.content = result.content;
             last.status = undefined;
           }
@@ -699,7 +800,20 @@ export const useChatStore = create<ChatStore>((set, get) => ({
               updateStreamingConversation(conv => {
                 const messages = [...conv.messages];
                 const last = messages[messages.length - 1];
-                if (last?.role === 'assistant') last.status = undefined;
+                if (last?.role === 'assistant') {
+                  if (last.toolEvents?.length) {
+                    const nextEvents = [...last.toolEvents];
+                    const lastEvent = nextEvents[nextEvents.length - 1];
+                    if (lastEvent && !lastEvent.endedAt) {
+                      nextEvents[nextEvents.length - 1] = {
+                        ...lastEvent,
+                        endedAt: Date.now(),
+                      };
+                    }
+                    last.toolEvents = nextEvents;
+                  }
+                  last.status = undefined;
+                }
                 return { ...conv, messages };
               });
             }
@@ -724,7 +838,20 @@ export const useChatStore = create<ChatStore>((set, get) => ({
             if (finalConv) {
               const messages = [...finalConv.messages];
               const last = messages[messages.length - 1];
-              if (last && last.role === 'assistant') last.status = undefined;
+              if (last && last.role === 'assistant') {
+                if (last.toolEvents?.length) {
+                  const nextEvents = [...last.toolEvents];
+                  const lastEvent = nextEvents[nextEvents.length - 1];
+                  if (lastEvent && !lastEvent.endedAt) {
+                    nextEvents[nextEvents.length - 1] = {
+                      ...lastEvent,
+                      endedAt: Date.now(),
+                    };
+                  }
+                  last.toolEvents = nextEvents;
+                }
+                last.status = undefined;
+              }
               const updatedConv = { ...finalConv, messages };
               StorageService.saveConversation(updatedConv);
 
@@ -744,6 +871,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
             }
           },
           (error: string) => {
+            closeLastToolEvent(streamingConversationId, assistantMessage.id);
             set({ 
               error: `Error: ${error}`,
               isStreaming: false,
@@ -759,6 +887,97 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         isStreaming: false,
       });
     }
+  },
+
+  regenerateAt: async (assistantMessageIndex: number) => {
+    const state = get();
+    const { currentConversation, isStreaming } = state;
+    if (!currentConversation || isStreaming) {
+      return;
+    }
+
+    const messages = currentConversation.messages;
+    if (
+      assistantMessageIndex < 0 ||
+      assistantMessageIndex >= messages.length ||
+      messages[assistantMessageIndex].role !== 'assistant'
+    ) {
+      return;
+    }
+
+    let userMessageIndex = -1;
+    for (let index = assistantMessageIndex - 1; index >= 0; index -= 1) {
+      if (messages[index].role === 'user') {
+        userMessageIndex = index;
+        break;
+      }
+    }
+
+    if (userMessageIndex < 0) {
+      return;
+    }
+
+    const userMessage = messages[userMessageIndex];
+    const staleAssistant = messages[assistantMessageIndex];
+    const trimmedConversation: Conversation = {
+      ...currentConversation,
+      messages: messages.slice(0, userMessageIndex + 1),
+      updatedAt: Date.now(),
+    };
+
+    const conversations = state.conversations.map((conversation) =>
+      conversation.id === trimmedConversation.id ? trimmedConversation : conversation
+    );
+
+    set({
+      currentConversation: trimmedConversation,
+      conversations,
+    });
+    StorageService.saveConversation(trimmedConversation);
+
+    await get().sendMessage(userMessage.content, false, {
+      parentMessageId: staleAssistant.id,
+    });
+  },
+
+  editAndResubmit: async (userMessageIndex: number, newContent: string) => {
+    const state = get();
+    const { currentConversation, isStreaming } = state;
+    const normalizedContent = newContent.trim();
+
+    if (!currentConversation || isStreaming || !normalizedContent) {
+      return;
+    }
+
+    const messages = currentConversation.messages;
+    if (
+      userMessageIndex < 0 ||
+      userMessageIndex >= messages.length ||
+      messages[userMessageIndex].role !== 'user'
+    ) {
+      return;
+    }
+
+    const originalUserMessage = messages[userMessageIndex];
+    const trimmedConversation: Conversation = {
+      ...currentConversation,
+      messages: messages.slice(0, userMessageIndex),
+      updatedAt: Date.now(),
+    };
+
+    const conversations = state.conversations.map((conversation) =>
+      conversation.id === trimmedConversation.id ? trimmedConversation : conversation
+    );
+
+    set({
+      currentConversation: trimmedConversation,
+      conversations,
+    });
+    StorageService.saveConversation(trimmedConversation);
+
+    await get().sendMessage(normalizedContent, false, {
+      editedFrom: originalUserMessage.content,
+    });
   },
 
   // Load a conversation

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,14 @@ export interface ToolResultMessage {
   name?: string; // Tool name for context
 }
 
+export interface ToolEvent {
+  type: 'thinking' | 'search' | 'tool_call' | 'tool_result';
+  label: string;
+  startedAt: number;
+  endedAt?: number;
+  detail?: string;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant' | 'system' | 'tool';
@@ -36,6 +44,9 @@ export interface Message {
   // UI status for assistant placeholder: searching/ thinking while awaiting content
   status?: 'searching' | 'thinking' | 'typing';
   lastSearchQuery?: string; // Phase 2B: Track what was searched for better UX
+  toolEvents?: ToolEvent[];
+  parentMessageId?: string;
+  editedFrom?: string;
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary
- add per-message action framework with assistant actions and user edit-and-resubmit path
- add collapsible Activity timeline UI for tool/search/thinking steps (default collapsed)
- mount lightweight in-chat document drawer and trigger row for managing attached docs
- extend store/types with message metadata (`toolEvents`, `parentMessageId`, `editedFrom`) and new actions (`regenerateAt`, `editAndResubmit`)
- add focused tests for timeline, doc drawer, and store actions

## Validation
- npm test -- chat-message-actions tool-timeline doc-drawer chatStore.actions.integration

## Notes
- rolled back the input-repeat troubleshooting changes per request; branch is restored to pre-investigation behavior for that issue
- no new emoji usage introduced in the new P1 UI
